### PR TITLE
hardware_legacy: allow alternative vibrator implementations

### DIFF
--- a/vibrator/Android.mk
+++ b/vibrator/Android.mk
@@ -2,3 +2,9 @@
 
 LOCAL_SRC_FILES += vibrator/vibrator.c
 
+## Must point to a source file that implements the sendit() function
+ifneq ($(BOARD_HAS_VIBRATOR_IMPLEMENTATION),)
+    LOCAL_SRC_FILES += $(BOARD_HAS_VIBRATOR_IMPLEMENTATION)
+    LOCAL_CFLAGS += -DUSE_ALTERNATIVE_VIBRATOR
+endif
+


### PR DESCRIPTION
The native vibrator code in libhardware_legacy assumes the vibrator
is always controlled by inputting timers into sysfs (at
/sys/class/timed_output/vibrator/enable). This isn't necessarily true,
there's an upcoming device which has the vibrator controlled by ioctl()
calls.

This patch lets the device configuration specify an alternative 
vibrator implementation throught the variable BOARD_HAS_VIBRATOR_IMPLEMENTATION 

That variable should point to a sourcefile that implements the vibrator
"int sendit(timeout_ms)" function, like this:

BOARD_HAS_VIBRATOR_IMPLEMENTATION := ../../device/vendor/model/vibrator.c
