### PR TITLE
hardware_legacy: allow alternative vibrator implementations

### DIFF
--- a/vibrator/vibrator.c
+++ b/vibrator/vibrator.c
@@ -21,6 +21,10 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#ifdef USE_ALTERNATIVE_VIBRATOR
+extern int sendit(int timeout_ms);
+#else
+
 #define THE_DEVICE "/sys/class/timed_output/vibrator/enable"
 
 int vibrator_exists()
@@ -62,6 +66,8 @@ static int sendit(int timeout_ms)
 
     return (ret == nwr) ? 0 : -1;
 }
+
+#endif
 
 int vibrator_on(int timeout_ms)
 {


### PR DESCRIPTION
The native vibrator code in libhardware_legacy assumes the vibrator
is always controlled by inputting timers into sysfs (at
/sys/class/timed_output/vibrator/enable). This isn't necessarily true,
there's an upcoming device which has the vibrator controlled by ioctl()
calls.

This patch lets the device configuration specify an alternative 
vibrator implementation throught the variable BOARD_HAS_VIBRATOR_IMPLEMENTATION 

That variable should point to a sourcefile that implements the vibrator
"int sendit(timeout_ms)" function, like this:

BOARD_HAS_VIBRATOR_IMPLEMENTATION := ../../device/vendor/model/vibrator.c
